### PR TITLE
fix(XorRightShift) + some typos

### DIFF
--- a/src/include/HashFunction.hpp
+++ b/src/include/HashFunction.hpp
@@ -42,7 +42,7 @@ public:
         bool ongoing_overflow{false};
         for (std::unique_ptr<Operator<myuint>> & op_ptr : m_operators)
         {
-            // Skip the loop is the operator is a masking operator
+            // Skip the loop if the operator is a masking operator
             if (auto const* masking_ptr = dynamic_cast<const Masking<myuint>*>(op_ptr.get())) {
                 // op_ptr est de type std::unique_ptr<Masking<myuint>>
                 continue;

--- a/src/include/Masking.hpp
+++ b/src/include/Masking.hpp
@@ -49,7 +49,7 @@ public:
     {
         return false;
     }
-    
+
     bool clean_leftbits_needed() const override
     {
         return false;

--- a/src/include/XorLeftShift.hpp
+++ b/src/include/XorLeftShift.hpp
@@ -4,7 +4,6 @@
 
 #include "Operator.hpp"
 
-
 #ifndef XORLEFTSHIFT_HPP
 #define XORLEFTSHIFT_HPP
 
@@ -29,7 +28,7 @@ public:
     std::vector<std::unique_ptr<Operator<myuint>>> invert() const override
     {
         std::vector<std::unique_ptr<Operator<myuint>>> inverted{};
-        
+
         // We start from the number of shifts and we double it until we reach the size of the myuint type
         // Doing so, we will be able to recover the original value in logaritmic time
         for (size_t recover_size{m_shifts}; recover_size < m_value_size; recover_size *= 2)
@@ -57,7 +56,7 @@ public:
     {
         return true;
     }
-    
+
     bool clean_leftbits_needed() const override
     {
         return false;

--- a/src/include/XorRightShift.hpp
+++ b/src/include/XorRightShift.hpp
@@ -16,24 +16,24 @@ class XorRightShift : public Operator<myuint>
 private:
     // The number of shifts to apply
     size_t m_shifts;
-    // The size of the variable to manipulate
-    size_t m_val_size;
+    // The size (in bits) of the values to manipulate
+    size_t m_value_size;
 
 public:
-    XorRightShift(size_t shifts, size_t val_size) : m_shifts(shifts), m_val_size(val_size) {}
-    XorRightShift(XorRightShift const & other) : XorRightShift(other.shifts) {}
+    XorRightShift(size_t shifts, size_t value_size) : m_shifts(shifts), m_value_size(value_size) {}
+    XorRightShift(XorRightShift const & other) : XorRightShift(other.shifts, other.m_value_size) {}
     ~XorRightShift() {}
 
     // Implement the invert function
     std::vector<std::unique_ptr<Operator<myuint>>> invert() const override
     {
-        std::vector<std::unique_ptr<Operator<myuint>>> inverted;
-        
+        std::vector<std::unique_ptr<Operator<myuint>>> inverted{};
+
         // We start from the number of shifts and we double it until we reach the size of the myuint type
         // Doing so, we will be able to recover the original value in logaritmic time
-        for (size_t recover_size{m_shifts}; recover_size < m_val_size; recover_size *= 2)
+        for (size_t recover_size{m_shifts}; recover_size < m_value_size; recover_size *= 2)
         {
-            inverted.push_back(std::make_unique<XorRightShift<myuint>>(recover_size, m_val_size));
+            inverted.push_back(std::make_unique<XorRightShift<myuint>>(recover_size, m_value_size));
         }
 
         return inverted;
@@ -47,7 +47,7 @@ public:
         return ss.str();
     }
 
-    myuint apply (myuint value) const override
+    myuint apply(myuint value) const override
     {
         return value ^ (value >> m_shifts);
     }
@@ -56,7 +56,7 @@ public:
     {
         return false;
     }
-    
+
     bool clean_leftbits_needed() const override
     {
         return true;


### PR DESCRIPTION
Fix:
- Adds missing member in XorRightShift copy constructor.

Refactor for consistency across *Shift classes:
- Rename `val_size` as `value_size`.
- Adds an empty init for the `inverted` vector.
- Use the same comments for similar members.

Typo:
- Remove superfluous spaces.